### PR TITLE
Treat SmartQuote as text, not markup

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -179,6 +179,7 @@ impl State {
 			},
 			SyntaxKind::Space if self.mode == Mode::Markdown => output.add_text(node.text().into()),
 			SyntaxKind::Parbreak => output.add_encoded(node.text().into(), String::from("\n\n")),
+			SyntaxKind::SmartQuote if self.mode == Mode::Markdown => output.add_text(node.text().into()),
 			_ => {
 				output.add_markup(node.text().into());
 				for child in node.children() {


### PR DESCRIPTION
Hi,
While trying out this tool I found that LanguageTool reported errors where there are none. For example `don't` results in `EN_CONTRACTION_SPELLING` and `world's` in `POSSESSIVE_APOSTROPHE`, both related to lack of an apostrophe in a word. Short investigation later I found that `State::convert` converts `SyntaxKind::SmartQuote` as markup, and ignores the apostrophe symbol. 
I've made this simple change, and it solves this problem, but I'm not sure if this is the best way, as I didn't really analyze how the code works. So if there's a better way, let me know. 

Tested the change on this fragment, straight from [typst tutorial](https://typst.app/docs/tutorial/writing-in-typst/):
```typst
Glaciers as the one shown in
@glaciers will cease to exist if
we don't take action soon!

#figure(
  image("glacier.jpg", width: 70%),
  caption: [
    _Glaciers_ form an important part
    of the earth's climate system.
  ],
) <glaciers>
```


Versions:
- typst v0.9.0
- LanguageTool 6.3 (also tested 6.2)

Also, thanks for the tool, it really helps :D