### PR TITLE
Add support for custom dictionaries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,6 @@ fn filter_response(response: &mut CheckResponse, dict: &HashSet<String>) {
 		let end = chars
 			.nth(ctx.length.wrapping_sub(1))
 			.map_or(ctx.text.len(), |(idx, _)| idx);
-        print!("({start}, {end})");
 		let word = &ctx.text[start..end];
 		if dict.contains(word) {
 			continue;


### PR DESCRIPTION
This PR adds the `-w`/`--dictionary` flag, which allows specifying a dictionary file.
The dictionary file contains one word on each line. These words are ignored when LanguageTool reports misspellings.
Example dictionary file:
```
alowed
woords
go-here
``` 
If LanguageTool reports the words `alowed`, `woords` or `go-here` as misspellings, they are ignored and not reported.