### PR TITLE
Add nvim support and documentation

### DIFF
--- a/editors/nvim/typst.lua
+++ b/editors/nvim/typst.lua
@@ -1,0 +1,24 @@
+-- ftplugin/typst.lua
+--
+-- This setup detects a main.typst file and compiles it
+
+local root_files = { 'main.typst' }
+local paths = vim.fs.find(root_files, { stop = vim.env.HOME })
+local root_dir = vim.fs.dirname(paths[1])
+
+if root_dir then
+  vim.lsp.start({
+    cmd = { 'typst-languagetool-lsp' },
+    filetype = { 'typst' },
+    root_dir = root_dir,
+    init_options = {
+      bundeled = true,
+      -- jar_location = "path/to/jar/location"
+      -- host = "http://127.0.0.1",
+      -- port = "8081",
+      root = root_dir,
+      main = root_dir .. "/main.typst",
+      languages = { "fr", "en-US" }
+    },
+  })
+end

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,15 @@ If another region is desired, it can be specified in the language parameter.
 	- configure options (see below)
 	- hints should appear
 		- first check takes longer
+- neovim
+	- install language server protocal (LSP)
+		- `cargo install --git=https://github.com/antonWetzel/typst-languagetool lsp --features=...`
+    - copy the `editors/nvim/typst.lua` file in the `ftplugin/` folder (should be in the nvim config path)
+	- configure options in `init_option` (see below)
+    - create a `main.typst` file and include your typst files inside if needed
+	- hints should appear (if not use `set filetype=typst` to force the type)
+		- first check takes longer
+
 
 ## LSP Options
 


### PR DESCRIPTION
Add nvim support for typst-languagetool
It uses ftplugin to start the server

The default config looks for a `main.typst` file and use it to compile the project

Add documentation to set up nvim