### PR TITLE
Neovim: update the example ftplugin file

### DIFF
--- a/editors/nvim/typst.lua
+++ b/editors/nvim/typst.lua
@@ -12,13 +12,12 @@ if root_dir then
     filetype = { 'typst' },
     root_dir = root_dir,
     init_options = {
-      bundeled = true,
       -- jar_location = "path/to/jar/location"
       -- host = "http://127.0.0.1",
       -- port = "8081",
       root = root_dir,
       main = root_dir .. "/main.typst",
-      languages = { "fr", "en-US" }
+      languages = { de = "de-DE", en = "en-US" }
     },
   })
 end


### PR DESCRIPTION
The current Neovim example configuration does not work with the latest changes on the repository. Therefore, I updated the example file to mitigate the troubles discussed in Issue #36.

This change reflects the information from https://github.com/antonWetzel/typst-languagetool/issues/36