### PR TITLE
bump version of languagetool-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "languagetool-rust"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242e2a8ec49c86d3044354c020c9838c8ff85ff2121a9b5562abebda41fc5bbc"
+checksum = "04508170152a42817f6b5a016e550afa7e4822ae395ed7e4df38bad0f775a220"
 dependencies = [
  "annotate-snippets 0.9.2",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = "1.0.104"
 jni = { version = "0.21.1", features = ["invocation"] }
 serde_ignored = "0.1.10"
 anyhow = "1.0.71"
-languagetool-rust = "2.1.4"
+languagetool-rust = "2.1.5"
 tokio = { version = "1.37.0", features = [
     "rt",
     "macros",


### PR DESCRIPTION
This pull reuest bumps the languagetool-rust version up to 2.1.5 . This version is more compliant to the languagetool API and would enable the usage of other language tool like servers (e.g. [ltapiserv-rs](https://github.com/cpg314/ltapiserv-rs))