### PR TITLE
Use Options `languages` Region Override for Determining LanguageTool language

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -216,7 +216,10 @@ async fn handle_file(
 	let mut collector = typst_languagetool::FileCollector::new(file_id_opt, &world);
 	let mut next_cache = Cache::new();
 	for (text, mapping) in paragraphs {
-		let lang = mapping.long_language();
+		let lang = match args.lt.languages.get(mapping.short_language()) {
+			Some(lang) => lang.clone(),
+			None => mapping.long_language(),
+		};
 		let suggestions = if let Some(suggestions) = cache.get(&text, &lang) {
 			suggestions
 		} else {


### PR DESCRIPTION
The `languages` field of the options file seems to be meant to override the default region selection for a given language.
Currently, this does not seem to work, as `en-GB` is always selected regardless of the values in the file.

I implemented this functionality to select analysis language with respect to the `languages` section of the options file. If no overrides are found, then the current default behavior is used.