### PR TITLE
Fix a "file not found" issue in LSP

### DIFF
--- a/lsp/src/main.rs
+++ b/lsp/src/main.rs
@@ -583,7 +583,7 @@ fn byte_to_position(source: &Source, index: usize) -> (usize, usize) {
 }
 
 fn uri_path(uri: &Uri) -> PathBuf {
-	let path = &uri.path().as_str()[1..]; // skip remaining '/'
+	let path = &uri.path().as_str();
 	let path = percent_encoding::percent_decode_str(path)
 		.decode_utf8()
 		.unwrap();


### PR DESCRIPTION
Hi. I was getting a mysterious "Language server exited" in helix and I decided to dig a bit.

It turns out that when `State::file_open` calls `uri_path` with `params.text_document` (`DidOpenTextDocumentParams::TextDocumentItem`), the URI that the lsp has received is an absolute path e.g. `/home/gustafla/.../document.typ`. Then the logic in `uri_path` strips the leading `/`, which makes the absolute path a nonsensical relative path (e.g. `home/gustafla/...`). Then the `use_shadow_file`-call fails to find the file.

My fix in this PR just uses the URI directly, but I don't know what might break. Maybe it doesn't work with other editors than Helix?

```
2025-09-26T15:28:14.068 helix_lsp::transport [ERROR] typst-languagetool err <- "Starting LSP server\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "Options: InitOptions {\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "    on_change: None,\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "    options: None,\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "    lt: LanguageToolOptions {\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        root: None,\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        main: None,\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        chunk_size: 1000,\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        backend: Some(\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "            Bundle,\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        ),\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        languages: {},\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        dictionary: {},\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        disabled_checks: {},\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        ignore_functions: {\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "            \"cite\",\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "            \"lorem\",\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "            \"bibliography\",\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "        },\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "    },\n"
2025-09-26T15:28:14.069 helix_lsp::transport [ERROR] typst-languagetool err <- "}\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "Compiling document\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "Waiting for events\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "Options: InitOptions {\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "    on_change: None,\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "    options: None,\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "    lt: LanguageToolOptions {\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        root: None,\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        main: None,\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        chunk_size: 1000,\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        backend: Some(\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "            Bundle,\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        ),\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        languages: {},\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        dictionary: {},\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        disabled_checks: {},\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        ignore_functions: {\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "            \"bibliography\",\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "            \"cite\",\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "            \"lorem\",\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "        },\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "    },\n"
2025-09-26T15:28:14.327 helix_lsp::transport [ERROR] typst-languagetool err <- "}\n"
2025-09-26T15:28:14.328 helix_lsp::transport [ERROR] typst-languagetool err <- "JNI call failed\n"
2025-09-26T15:28:14.328 helix_lsp::transport [ERROR] typst-languagetool err <- "Open home/gustafla/coursework/csm_thesis_plan.typ\n"
2025-09-26T15:28:14.328 helix_lsp::transport [ERROR] typst-languagetool err <- "\n"
2025-09-26T15:28:14.328 helix_lsp::transport [ERROR] typst-languagetool err <- "thread 'main' panicked at lt-world/src/lib.rs:70:40:\n"
2025-09-26T15:28:14.328 helix_lsp::transport [ERROR] typst-languagetool err <- "called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n"
2025-09-26T15:28:14.328 helix_lsp::transport [ERROR] typst-languagetool err <- "stack backtrace:\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   0:     0x55d9efa64db2 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h2d9b8700ea3f8773\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   1:     0x55d9efa939a3 - core::fmt::write::h53933d09fbc4b914\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   2:     0x55d9efa5fc73 - std::io::Write::write_fmt::h2dab5f844ce1d11a\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   3:     0x55d9efa64c02 - std::sys::backtrace::BacktraceLock::print::h0e7ac5587a1381f3\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   4:     0x55d9efa669a6 - std::panicking::default_hook::{{closure}}::h7eb78baed8cba063\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   5:     0x55d9efa667a9 - std::panicking::default_hook::h213e9dfba45ec23c\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   6:     0x55d9efa673b2 - std::panicking::rust_panic_with_hook::h6de6c1ab1a7f789d\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   7:     0x55d9efa6714a - std::panicking::begin_panic_handler::{{closure}}::h83af383f9e6de660\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   8:     0x55d9efa652a9 - std::sys::backtrace::__rust_end_short_backtrace::h569a86ab2aba4faa\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "   9:     0x55d9efa66ddd - __rustc[ac9b6737c369adb]::rust_begin_unwind\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  10:     0x55d9efa90820 - core::panicking::panic_fmt::h583f463a6f50f113\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  11:     0x55d9efa90ce6 - core::result::unwrap_failed::h4e3f14bab0c41ca4\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  12:     0x55d9ed72fae3 - core::result::Result<T,E>::unwrap::h58ed751d7a77fca1\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /usr/src/debug/rust/rustc-1.89.0-src/library/core/src/result.rs:1167:23\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  13:     0x55d9ed72fae3 - lt_world::LtWorld::file_id::hbc6062a305c6b09a\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/typst-languagetool/lt-world/src/lib.rs:70:34\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  14:     0x55d9ed72fd83 - lt_world::LtWorld::use_shadow_file::h6a7fc16f6b47163a\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/typst-languagetool/lt-world/src/lib.rs:77:28\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  15:     0x55d9ed5ffec2 - typst_languagetool_lsp::State::file_open::{{closure}}::h6a4d6b93f851bd1a\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/typst-languagetool/lsp/src/main.rs:317:14\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  16:     0x55d9ed5ff489 - typst_languagetool_lsp::State::notification::{{closure}}::h97d41c0e4547112e\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/typst-languagetool/lsp/src/main.rs:275:48\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  17:     0x55d9ed5fc4b2 - typst_languagetool_lsp::State::message::{{closure}}::hcbdb5ed488bd8f19\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/typst-languagetool/lsp/src/main.rs:197:57\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  18:     0x55d9ed5fba55 - typst_languagetool_lsp::State::main_loop::{{closure}}::hd49366bd262bc658\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/typst-languagetool/lsp/src/main.rs:162:47\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "  19:     0x55d9ed6076e2 - typst_languagetool_lsp::main::{{closure}}::h3dd333af9732ca72\n"
2025-09-26T15:28:14.362 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/typst-languagetool/lsp/src/main.rs:81:20\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "  20:     0x55d9ed60d49d - <core::pin::Pin<P> as core::future::future::Future>::poll::h400de9d4701498a4\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /usr/src/debug/rust/rustc-1.89.0-src/library/core/src/future/future.rs:124:9\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "  21:     0x55d9ed5459cf - tokio::runtime::park::CachedParkThread::block_on::{{closure}}::h63bd99dd946a3dae\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/park.rs:285:71\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "  22:     0x55d9ed544ecf - tokio::task::coop::with_budget::hcd6c15bb1904f53a\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:167:5\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "  23:     0x55d9ed544ecf - tokio::task::coop::budget::h3e04426ff759b89d\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:133:5\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "  24:     0x55d9ed544ecf - tokio::runtime::park::CachedParkThread::block_on::h57a43504aaa12ebf\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/park.rs:285:31\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "  25:     0x55d9ed4d5630 - tokio::runtime::context::blocking::BlockingRegionGuard::block_on::h7b34c7738955fb34\n"
2025-09-26T15:28:14.363 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/blocking.rs:66:14\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "  26:     0x55d9ed549b2e - tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}::h5a2edcd372c28601\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/mod.rs:87:22\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "  27:     0x55d9ed4806d2 - tokio::runtime::context::runtime::enter_runtime::h0a69bb2aefbdad23\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/runtime.rs:65:16\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "  28:     0x55d9ed549aa1 - tokio::runtime::scheduler::multi_thread::MultiThread::block_on::h95d6a401d84a7985\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/mod.rs:86:9\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "  29:     0x55d9ed5f8d50 - tokio::runtime::runtime::Runtime::block_on_inner::h53e54d78873df107\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:358:50\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "  30:     0x55d9ed5f924b - tokio::runtime::runtime::Runtime::block_on::hadb3b932271bfe87\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:328:18\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "  31:     0x55d9ed48011e - typst_languagetool_lsp::main::h8e3cfb72ab752ce8\n"
2025-09-26T15:28:14.364 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /home/gustafla/typst-languagetool/lsp/src/main.rs:85:4\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  32:     0x55d9ed57cbeb - core::ops::function::FnOnce::call_once::h6005ac92a2e8c4e2\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /usr/src/debug/rust/rustc-1.89.0-src/library/core/src/ops/function.rs:250:5\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  33:     0x55d9ed54b9ad - std::sys::backtrace::__rust_begin_short_backtrace::h9af9cd518adc6998\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /usr/src/debug/rust/rustc-1.89.0-src/library/std/src/sys/backtrace.rs:152:18\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  34:     0x55d9ed607ba1 - std::rt::lang_start::{{closure}}::hbe1461b1d3f686d9\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /usr/src/debug/rust/rustc-1.89.0-src/library/std/src/rt.rs:206:18\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  35:     0x55d9efa555b0 - std::rt::lang_start_internal::h4fe7c775febbe9e1\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  36:     0x55d9ed607b87 - std::rt::lang_start::hb08cb0144deeabe6\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "                               at /usr/src/debug/rust/rustc-1.89.0-src/library/std/src/rt.rs:205:5\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  37:     0x55d9ed4801ce - main\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  38:     0x7f1e07e27675 - <unknown>\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  39:     0x7f1e07e27729 - __libc_start_main\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  40:     0x55d9ed47e795 - _start\n"
2025-09-26T15:28:14.365 helix_lsp::transport [ERROR] typst-languagetool err <- "  41:                0x0 - <unknown>\n"
2025-09-26T15:28:14.368 helix_lsp::transport [ERROR] typst-languagetool err: <- StreamClosed
```