### PR TITLE
Also ignore errors for nodes that are children of ignored function calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,6 +3711,7 @@ dependencies = [
  "anyhow",
  "jni",
  "languagetool-rust",
+ "lt-world",
  "serde",
  "typst",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ jni = { workspace = true, optional = true }
 anyhow.workspace = true
 languagetool-rust = { workspace = true, optional = true }
 
+[dev-dependencies]
+lt-world.workspace = true
+
 [workspace]
 members = [".", "cli", "lsp", "lt-world"]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,6 +20,9 @@ use std::{
 	time::Duration,
 };
 
+#[cfg(not(any(feature = "bundle", feature = "jar", feature = "server")))]
+compile_error!("No backends enabled, the backends can be enabled with feature flags");
+
 #[derive(ValueEnum, Clone, Debug)]
 enum Task {
 	Check,

--- a/example/content_block.typ
+++ b/example/content_block.typ
@@ -1,0 +1,6 @@
+#let prog(content) = content
+
+#prog[mistaek]
+
+#prog([anohter mistaek])
+

--- a/example/ignore.typ
+++ b/example/ignore.typ
@@ -1,0 +1,4 @@
+#let ignorespelling(content) = content
+#let lambdarust = ignorespelling($lambda_"Rust"$)
+
+RustBelt developed #lambdarust: a model of Rust formalized in Rocq.

--- a/lsp/src/main.rs
+++ b/lsp/src/main.rs
@@ -13,6 +13,9 @@ use serde_json::Value;
 use typst::World;
 use typst_languagetool::{LanguageTool, LanguageToolBackend, LanguageToolOptions, Suggestion};
 
+#[cfg(not(any(feature = "bundle", feature = "jar", feature = "server")))]
+compile_error!("No backends enabled, the backends can be enabled with feature flags");
+
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
 #[serde(default)]
 struct InitOptions {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -9,6 +9,31 @@ use typst::{
 
 use crate::Suggestion;
 
+fn is_call_to_ignored_function(
+	node: &typst::syntax::LinkedNode,
+	ignore_functions: &HashSet<String>,
+) -> bool {
+	match node.kind() {
+		SyntaxKind::FuncCall => node
+			.leftmost_leaf()
+			.map(|leaf| ignore_functions.contains(leaf.text().as_str()))
+			.unwrap_or(false),
+		SyntaxKind::Ref => ignore_functions.contains("cite"),
+		_ => false,
+	}
+}
+
+fn should_ignore(node: &typst::syntax::LinkedNode, ignore_functions: &HashSet<String>) -> bool {
+	let mut current = Some(node);
+	while let Some(node) = current {
+		if is_call_to_ignored_function(node, ignore_functions) {
+			return true;
+		}
+		current = node.parent();
+	}
+	false
+}
+
 #[derive(Debug)]
 pub struct Mapping {
 	chars: Vec<(Span, Range<u16>)>,
@@ -45,6 +70,10 @@ impl Mapping {
 				continue;
 			};
 
+			if should_ignore(&node, ignore_functions) {
+				continue;
+			}
+
 			match node.kind() {
 				SyntaxKind::Text => {
 					let start = node.range().start;
@@ -58,9 +87,6 @@ impl Mapping {
 						_ => locations.push((id, range)),
 					}
 				},
-				SyntaxKind::FuncCall
-					if ignore_functions.contains(node.leftmost_leaf().unwrap().text().as_str()) => {},
-				SyntaxKind::Ref if ignore_functions.contains("cite") => {},
 				_ => {
 					let range = node.range();
 					match locations.last_mut() {
@@ -249,5 +275,100 @@ impl Converter {
 			},
 			I::Link(..) | I::Tag(..) | I::Shape(..) | I::Image(..) => {},
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::Suggestion;
+	use std::path::Path;
+
+	struct TestHarness<'a> {
+		world: lt_world::LtWorldRunning<'a>,
+		text: String,
+		mapping: Mapping,
+	}
+
+	impl<'a> TestHarness<'a> {
+		fn new(world: &'a lt_world::LtWorld, main_file: &Path) -> Self {
+			let world = world.with_main(main_file.to_path_buf());
+			let doc = world.compile().unwrap();
+			let paragraphs = document(&doc, 1000, None);
+			assert_eq!(paragraphs.len(), 1, "expected exactly one paragraph");
+			let (text, mapping) = paragraphs.into_iter().next().unwrap();
+			Self { world, text, mapping }
+		}
+
+		fn suggestion_for(&self, needle: &str) -> Suggestion {
+			let start = self
+				.text
+				.find(needle)
+				.unwrap_or_else(|| panic!("expected '{}' in text: {:?}", needle, self.text));
+			Suggestion {
+				start,
+				end: start + needle.len(),
+				message: "test".into(),
+				replacements: vec![],
+				rule_description: "test".into(),
+				rule_id: "test".into(),
+			}
+		}
+
+		fn locations_with_ignore(
+			&self,
+			suggestion: &Suggestion,
+			ignore_functions: &[&str],
+		) -> Vec<(typst::syntax::FileId, std::ops::Range<usize>)> {
+			let ignore_set: HashSet<String> =
+				ignore_functions.iter().map(|s| s.to_string()).collect();
+			self.mapping
+				.location(suggestion, &self.world, None, &ignore_set)
+		}
+
+		fn is_ignored(&self, needle: &str, ignore_functions: &[&str]) -> bool {
+			let suggestion = self.suggestion_for(needle);
+			self.locations_with_ignore(&suggestion, ignore_functions)
+				.is_empty()
+		}
+	}
+
+	#[test]
+	fn test_ignore_functions_filters_ancestors() {
+		let world = lt_world::LtWorld::new("example".into());
+		let harness = TestHarness::new(&world, Path::new("example/ignore.typ"));
+
+		assert!(
+			harness.is_ignored("𝜆", &["ignorespelling"]),
+			"lambda should be ignored when ignorespelling is in ignore_functions"
+		);
+		assert!(
+			!harness.is_ignored("𝜆", &[]),
+			"lambda should not be ignored when ignorespelling is not in ignore_functions"
+		);
+	}
+
+	#[test]
+	fn test_ignore_functions_content_block_syntax() {
+		let world = lt_world::LtWorld::new("example".into());
+		let harness = TestHarness::new(&world, Path::new("example/content_block.typ"));
+
+		assert!(
+			harness.is_ignored("mistaek", &["prog"]),
+			"content in #prog[] should be ignored when prog is in ignore_functions"
+		);
+		assert!(
+			!harness.is_ignored("mistaek", &[]),
+			"content in #prog[] should not be ignored when prog is not in ignore_functions"
+		);
+
+		assert!(
+			harness.is_ignored("anohter", &["prog"]),
+			"content in #prog([]) should be ignored when prog is in ignore_functions"
+		);
+		assert!(
+			!harness.is_ignored("anohter", &[]),
+			"content in #prog([]) should not be ignored when prog is not in ignore_functions"
+		);
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@ use typst::{
 	syntax::{FileId, Source},
 };
 
-#[cfg(not(any(feature = "bundle", feature = "jar", feature = "server",)))]
-compile_error!("No backends enabled, the backends can be enabled with feature flags");
-
 #[allow(async_fn_in_trait)]
 pub trait LanguageToolBackend {
 	async fn allow_words(&mut self, lang: String, words: &[String]) -> anyhow::Result<()>;
@@ -31,8 +28,11 @@ pub enum LanguageTool {
 	JNI(jni::LanguageToolJNI),
 	#[cfg(feature = "server")]
 	Remote(remote::LanguageToolRemote),
+	#[cfg(test)]
+	_TestOnly(std::convert::Infallible),
 }
 
+#[cfg(any(feature = "bundle", feature = "jar", feature = "server"))]
 impl LanguageTool {
 	pub async fn new(options: &LanguageToolOptions) -> anyhow::Result<Self> {
 		let mut lt = match &options.backend {
@@ -77,6 +77,7 @@ impl LanguageTool {
 	}
 }
 
+#[cfg(any(feature = "bundle", feature = "jar", feature = "server"))]
 impl LanguageToolBackend for LanguageTool {
 	async fn allow_words(&mut self, lang: String, words: &[String]) -> anyhow::Result<()> {
 		match self {


### PR DESCRIPTION
For typst like:

```typst
#let ignorespelling(content) = content
#let specialname = ignorespelling("qwerty")

The name #specialname is special
```

A spelling error will be reported for the word "qwerty" even if `ignorespelling` is added to the list of ignored functions. It looks like the current behaviour is only to ignore nodes if they are function calls directly (e.g. `ignorespelling("qwerty")`)
but not for the inner node `"qwerty"` itself.

This PR changes the behaviour to ignore nodes if they are the child of any function call node to an ignored function; so the code above wouldn't raise an error.

Also, this PR adds tests for this new behaviour and slightly changes the feature detection logic so that tests can be run without specifying a backend.

This I think also addresses https://github.com/antonWetzel/typst-languagetool/issues/46

If the behaviour established in this PR isn't the intended behaviour feel free to close.